### PR TITLE
link to upstream teslajsonpy

### DIFF
--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -4,9 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/alandtse/tesla/wiki",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
-  "requirements": [
-    "git+https://github.com/shred86/teslajsonpy.git@rewrite-support#teslajsonpy==2.5.0"
-  ],
+  "requirements": ["teslajsonpy==3.0.0"],
   "codeowners": [
     "@alandtse"
   ],


### PR DESCRIPTION
Presumably, this can link back to main teslajsonpy, now the rewrite changes have been merged.